### PR TITLE
FIX: move frontmatter from site to project

### DIFF
--- a/pythia.yml
+++ b/pythia.yml
@@ -8,6 +8,9 @@ project:
     foundations: https://projectpythia-mystmd.github.io/pythia-foundations
     xarray: https://docs.xarray.dev/en/stable/
     matplotlib: https://matplotlib.org/stable/
+  jupyter:
+    binder:
+      url: https://binder.projectpythia.org/
     
 site:
   template: book-theme
@@ -29,6 +32,3 @@ site:
   actions:
     - title: Project Pythia
       url: https://projectpythia-mystmd.github.io
-  jupyter:
-    binder:
-      url: https://binder.projectpythia.org/


### PR DESCRIPTION
Frontmatter fields like `jupyter` can be set in the `project` section of `myst.yml` or page frontmatter YAML blocks. N.B. some fields can only be set in one of those places (see https://mystmd.org/guide/frontmatter#available-frontmatter-fields)